### PR TITLE
Late night PR

### DIFF
--- a/KSP/single_stage.py
+++ b/KSP/single_stage.py
@@ -65,7 +65,14 @@ class SingleStageCraft:
                     self.total_thrust -= engine_info[2] * count
                     self.mass_flow -= fuel_added * utils.fuel_masses[fuel_type]
                     self.fuel_consumption[fuel_type] -= fuel_added
-
+    def turn_engines_off(self):
+        for name, value in self.engine_activations.items():
+            self.engine_activations[name] = False
+        self.total_thrust = 0
+        self.mass_flow = 0
+        for fuel_type, value in self.fuel_consumption.items():
+            self.fuel_consumption[fuel_type] = 0
+    
     def simulate_burn(self, delta_time):
         # just reduce fuel levels and wet mass
         # Assumes infinite of each fuel type (for optimizing relative amounts).
@@ -75,5 +82,7 @@ class SingleStageCraft:
         self.wet_mass -= delta_time * self.mass_flow
 
     def get_average_isp(self):
+        if(self.mass_flow == 0):
+            return 0
         # Thrust in newtons divided by mass flow rate in kg/s
         return self.total_thrust / self.mass_flow


### PR DESCRIPTION
Improved single stage craft interface
    -Added turn_engines_off function. Does what it says on the box
    -Allowed isp calculation if all engines are off (just return 0)

Modified optimizer to be more customizable
    -Added allow_new_engines option. If false, only considers adjusting engines that are already there. Should also increase performance a lot.
    -Added lithobrake_speed so you can incorporate that into calculations as well.
    -Added allow_fractional option so you can choose to only use whole engines. Good for lower mass missions where you don't need exactly perfect ratios between engines.
    -Added output_ascent_profiles option so it doesn't clog console when running multiple optimization passes.
    -Added payload fraction output to better compare different masses of craft.

Misc fixes
    -Allowed simulate_landing_with_craft to use partial physics ticks for a more accurate payload fraction calculation. This should remove the weird behavior where the program would add a tiny engine for seemingly no reason.

Misc changes
    -Changed optimizer to simulate Vall and Tylo landings in succession, since that's my intended use case right now.